### PR TITLE
Refactor SQS Message

### DIFF
--- a/sqs/queue_test.go
+++ b/sqs/queue_test.go
@@ -16,21 +16,21 @@ func TestQueue(t *testing.T) {
 	t.Run("sends a message to the queue, receives it, and deletes it", func(t *testing.T) {
 		q := sqstest.CreateQueue(t)
 
-		err := q.Send(context.Background(), sqs.Message{
+		err := q.Send(context.Background(), sqs.Body{
 			"foo": "bar",
 		})
 		is.NotError(t, err)
 
-		m, receiptID, err := q.Receive(context.Background())
+		m, err := q.Receive(context.Background())
 		is.NotError(t, err)
 		is.NotNil(t, m)
-		is.Equal(t, "bar", (*m)["foo"])
-		is.True(t, len(receiptID) > 0)
+		is.Equal(t, "bar", m.Body["foo"])
+		is.True(t, len(m.ReceiptHandle) > 0)
 
-		err = q.Delete(context.Background(), receiptID)
+		err = q.Delete(context.Background(), m)
 		is.NotError(t, err)
 
-		m, _, err = q.Receive(context.Background())
+		m, err = q.Receive(context.Background())
 		is.NotError(t, err)
 		is.Nil(t, m)
 	})
@@ -39,12 +39,12 @@ func TestQueue(t *testing.T) {
 		q := sqstest.CreateQueue(t)
 
 		// Send first, to get the queue URL when the context is not cancelled
-		err := q.Send(context.Background(), sqs.Message{})
+		err := q.Send(context.Background(), sqs.Body{})
 		is.NotError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		m, _, err := q.Receive(ctx)
+		m, err := q.Receive(ctx)
 		is.NotError(t, err)
 		is.Nil(t, m)
 	})


### PR DESCRIPTION
Wrapping everything in a struct makes it easier down the road to not break the API.