### PR TITLE
Make the body an io.ReadSeeker in Bucket.Put

### DIFF
--- a/s3/bucket.go
+++ b/s3/bucket.go
@@ -35,7 +35,7 @@ func NewBucket(opts NewBucketOptions) *Bucket {
 }
 
 // Put an object under key with the given contentType.
-func (b *Bucket) Put(ctx context.Context, key, contentType string, body io.Reader) error {
+func (b *Bucket) Put(ctx context.Context, key, contentType string, body io.ReadSeeker) error {
 	_, err := b.Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &b.name,
 		Key:         &key,


### PR DESCRIPTION
Otherwise, errors like this pop up when the reader is not seekable:

```
operation error S3: PutObject, failed to compute payload hash: failed to seek body to start, request stream is not seekable
```